### PR TITLE
Get List of Installed Keyboards

### DIFF
--- a/src/keyboard-layout-observer-mac.mm
+++ b/src/keyboard-layout-observer-mac.mm
@@ -84,10 +84,8 @@ NAN_METHOD(KeyboardLayoutObserver::GetInstalledKeyboardLanguages) {
       TISInputSourceRef current = (TISInputSourceRef)[keyboardLayouts objectAtIndex:i];
 
       NSArray* langs = (NSArray*) TISGetInputSourceProperty(current, kTISPropertyInputSourceLanguages);
-      for (size_t j=0; j < 1; j++) {
-        std::string str = std::string([(NSString*)[langs objectAtIndex:j] UTF8String]);
-        ret.push_back(str);
-      }
+      std::string str = std::string([(NSString*)[langs objectAtIndex:0] UTF8String]);
+      ret.push_back(str);
     }
 
     filter = @{ (__bridge NSString *) kTISPropertyInputSourceType : (__bridge NSString *) kTISTypeKeyboardInputMode };
@@ -97,10 +95,8 @@ NAN_METHOD(KeyboardLayoutObserver::GetInstalledKeyboardLanguages) {
       TISInputSourceRef current = (TISInputSourceRef)[keyboardLayouts objectAtIndex:i];
 
       NSArray* langs = (NSArray*) TISGetInputSourceProperty(current, kTISPropertyInputSourceLanguages);
-      for (size_t j=0; j < 1; j++) {
-        std::string str = std::string([(NSString*)[langs objectAtIndex:j] UTF8String]);
-        ret.push_back(str);
-      }
+      std::string str = std::string([(NSString*)[langs objectAtIndex:0] UTF8String]);
+      ret.push_back(str);
     }
 
     Local<Array> result = NanNew<Array>(ret.size());

--- a/src/keyboard-layout-observer-mac.mm
+++ b/src/keyboard-layout-observer-mac.mm
@@ -17,7 +17,8 @@ void KeyboardLayoutObserver::Init(Handle<Object> target) {
   Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
 
   NODE_SET_METHOD(proto, "getCurrentKeyboardLayout", KeyboardLayoutObserver::GetCurrentKeyboardLayout);
-  NODE_SET_METHOD(proto, "getInstalledKeyboardLayouts", KeyboardLayoutObserver::GetInstalledKeyboardLayouts);
+  NODE_SET_METHOD(proto, "getCurrentKeyboardLanguage", KeyboardLayoutObserver::GetCurrentKeyboardLanguage);
+  NODE_SET_METHOD(proto, "getInstalledKeyboardLanguages", KeyboardLayoutObserver::GetInstalledKeyboardLanguages);
 
   target->Set(NanNew<String>("KeyboardLayoutObserver"), newTemplate->GetFunction());
 }
@@ -68,7 +69,7 @@ void KeyboardLayoutObserver::HandleKeyboardLayoutChanged() {
   callback->Call(0, NULL);
 }
 
-NAN_METHOD(KeyboardLayoutObserver::GetInstalledKeyboardLayouts) {
+NAN_METHOD(KeyboardLayoutObserver::GetInstalledKeyboardLanguages) {
   NanScope();
 
   @autoreleasepool {
@@ -110,6 +111,16 @@ NAN_METHOD(KeyboardLayoutObserver::GetInstalledKeyboardLayouts) {
 
     NanReturnValue(result);
   }
+}
+
+NAN_METHOD(KeyboardLayoutObserver::GetCurrentKeyboardLanguage) {
+  NanScope();
+  TISInputSourceRef source = TISCopyCurrentKeyboardInputSource();
+
+  NSArray* langs = (NSArray*) TISGetInputSourceProperty(source, kTISPropertyInputSourceLanguages);
+  NSString* lang = (NSString*) [langs objectAtIndex:0];
+
+  NanReturnValue(NanNew<String>([lang UTF8String]));
 }
 
 NAN_METHOD(KeyboardLayoutObserver::GetCurrentKeyboardLayout) {

--- a/src/keyboard-layout-observer-non-mac.cc
+++ b/src/keyboard-layout-observer-non-mac.cc
@@ -9,6 +9,7 @@ void KeyboardLayoutObserver::Init(Handle<Object> target) {
   newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
   Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
   NODE_SET_METHOD(proto, "getCurrentKeyboardLayout", KeyboardLayoutObserver::GetCurrentKeyboardLayout);
+  NODE_SET_METHOD(proto, "getInstalledKeyboardLayouts", KeyboardLayoutObserver::GetInstalledKeyboardLayouts);
   target->Set(NanNew<String>("KeyboardLayoutObserver"), newTemplate->GetFunction());
 }
 
@@ -36,6 +37,11 @@ void KeyboardLayoutObserver::HandleKeyboardLayoutChanged() {
 }
 
 NAN_METHOD(KeyboardLayoutObserver::GetCurrentKeyboardLayout) {
+  NanScope();
+  NanReturnValue(NanUndefined());
+}
+
+NAN_METHOD(KeyboardLayoutObserver::GetInstalledKeyboardLayouts) {
   NanScope();
   NanReturnValue(NanUndefined());
 }

--- a/src/keyboard-layout-observer-non-mac.cc
+++ b/src/keyboard-layout-observer-non-mac.cc
@@ -9,6 +9,7 @@ void KeyboardLayoutObserver::Init(Handle<Object> target) {
   newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
   Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
   NODE_SET_METHOD(proto, "getCurrentKeyboardLayout", KeyboardLayoutObserver::GetCurrentKeyboardLayout);
+  NODE_SET_METHOD(proto, "getCurrentKeyboardLanguage", KeyboardLayoutObserver::GetCurrentKeyboardLayout); // NB:  Intentionally mapped to same stub
   NODE_SET_METHOD(proto, "getInstalledKeyboardLayouts", KeyboardLayoutObserver::GetInstalledKeyboardLayouts);
   target->Set(NanNew<String>("KeyboardLayoutObserver"), newTemplate->GetFunction());
 }

--- a/src/keyboard-layout-observer-windows.cc
+++ b/src/keyboard-layout-observer-windows.cc
@@ -53,7 +53,8 @@ void KeyboardLayoutObserver::Init(Handle<Object> target) {
   Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
 
   NODE_SET_METHOD(proto, "getCurrentKeyboardLayout", KeyboardLayoutObserver::GetCurrentKeyboardLayout);
-  NODE_SET_METHOD(proto, "getInstalledKeyboardLayouts", KeyboardLayoutObserver::GetInstalledKeyboardLayouts);
+  NODE_SET_METHOD(proto, "getCurrentKeyboardLanguage", KeyboardLayoutObserver::GetCurrentKeyboardLanguage);
+  NODE_SET_METHOD(proto, "getInstalledKeyboardLanguages", KeyboardLayoutObserver::GetInstalledKeyboardLanguages);
   target->Set(NanNew<String>("KeyboardLayoutObserver"), newTemplate->GetFunction());
 }
 
@@ -83,6 +84,16 @@ void KeyboardLayoutObserver::HandleKeyboardLayoutChanged() {
 NAN_METHOD(KeyboardLayoutObserver::GetCurrentKeyboardLayout) {
   NanScope();
 
+  char layoutName[KL_NAMELENGTH];
+  if (::GetKeyboardLayoutName(layoutName))
+    NanReturnValue(NanNew(layoutName));
+  else
+    NanReturnValue(NanUndefined());
+}
+
+NAN_METHOD(KeyboardLayoutObserver::GetCurrentKeyboardLanguage) {
+  NanScope();
+
   HKL layout = GetKeyboardLayout(0 /* Current Thread */);
 
   wchar_t buf[LOCALE_NAME_MAX_LENGTH];
@@ -94,7 +105,7 @@ NAN_METHOD(KeyboardLayoutObserver::GetCurrentKeyboardLayout) {
   NanReturnValue(NanNew<String>(str.data(), str.size()));
 }
 
-NAN_METHOD(KeyboardLayoutObserver::GetInstalledKeyboardLayouts) {
+NAN_METHOD(KeyboardLayoutObserver::GetInstalledKeyboardLanguages) {
   NanScope();
 
   int layoutCount = GetKeyboardLayoutList(0, NULL);

--- a/src/keyboard-layout-observer-windows.cc
+++ b/src/keyboard-layout-observer-windows.cc
@@ -1,7 +1,49 @@
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0601
+
+#undef WINVER
+#define WINVER 0x0601
+
 #include "keyboard-layout-observer.h"
+
+#include <string>
 #include <windows.h>
 
 using namespace v8;
+
+std::string ToUTF8(const std::wstring& string) {
+  if (string.length() < 1) {
+    return std::string();
+  }
+
+  // NB: In the pathological case, each character could expand up
+  // to 4 bytes in UTF8.
+  int cbLen = (string.length()+1) * sizeof(char) * 4;
+  char* buf = new char[cbLen];
+  int retLen = WideCharToMultiByte(CP_UTF8, 0, string.c_str(), string.length(), buf, cbLen, NULL, NULL);
+  buf[retLen] = 0;
+
+  std::string ret;
+  ret.assign(buf);
+  return ret;
+}
+
+std::wstring ToWString(const std::string& string) {
+  if (string.length() < 1) {
+    return std::wstring();
+  }
+
+  // NB: If you got really unlucky, every character could be a two-wchar_t
+  // surrogate pair
+  int cchLen = (string.length()+1) * 2;
+  wchar_t* buf = new wchar_t[cchLen];
+  int retLen = MultiByteToWideChar(CP_UTF8, 0, string.c_str(), strlen(string.c_str()), buf, cchLen);
+  buf[retLen] = 0;
+
+  std::wstring ret;
+  ret.assign(buf);
+  return ret;
+}
 
 void KeyboardLayoutObserver::Init(Handle<Object> target) {
   NanScope();

--- a/src/keyboard-layout-observer-windows.cc
+++ b/src/keyboard-layout-observer-windows.cc
@@ -51,7 +51,9 @@ void KeyboardLayoutObserver::Init(Handle<Object> target) {
   newTemplate->SetClassName(NanNew<String>("KeyboardLayoutObserver"));
   newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
   Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
+
   NODE_SET_METHOD(proto, "getCurrentKeyboardLayout", KeyboardLayoutObserver::GetCurrentKeyboardLayout);
+  NODE_SET_METHOD(proto, "getInstalledKeyboardLayouts", KeyboardLayoutObserver::GetInstalledKeyboardLayouts);
   target->Set(NanNew<String>("KeyboardLayoutObserver"), newTemplate->GetFunction());
 }
 

--- a/src/keyboard-layout-observer.h
+++ b/src/keyboard-layout-observer.h
@@ -15,7 +15,8 @@ class KeyboardLayoutObserver : public node::ObjectWrap {
   ~KeyboardLayoutObserver();
   static NAN_METHOD(New);
   static NAN_METHOD(GetCurrentKeyboardLayout);
-  static NAN_METHOD(GetInstalledKeyboardLayouts);
+  static NAN_METHOD(GetCurrentKeyboardLanguage);
+  static NAN_METHOD(GetInstalledKeyboardLanguages);
 
   NanCallback *callback;
 };

--- a/src/keyboard-layout-observer.h
+++ b/src/keyboard-layout-observer.h
@@ -15,6 +15,7 @@ class KeyboardLayoutObserver : public node::ObjectWrap {
   ~KeyboardLayoutObserver();
   static NAN_METHOD(New);
   static NAN_METHOD(GetCurrentKeyboardLayout);
+  static NAN_METHOD(GetInstalledKeyboardLayouts);
 
   NanCallback *callback;
 };

--- a/src/keyboard-layout.coffee
+++ b/src/keyboard-layout.coffee
@@ -11,6 +11,10 @@ getCurrentKeyboardLanguage = ->
   observer.getCurrentKeyboardLanguage()
 
 getInstalledKeyboardLanguages = ->
+  # NB: This method returns one language per input method, and users can have
+  # >1 layout that matches a given language (i.e. Japanese probably has Hiragana
+  # and Katakana, both would correspond to the language "ja"), so we need to
+  # dedupe this list.
   rawList = observer.getInstalledKeyboardLanguages()
 
   ret = []

--- a/src/keyboard-layout.coffee
+++ b/src/keyboard-layout.coffee
@@ -7,6 +7,9 @@ observer = new KeyboardLayoutObserver -> emitter.emit 'did-change-current-keyboa
 getCurrentKeyboardLayout = ->
   observer.getCurrentKeyboardLayout()
 
+getInstalledKeyboardLayouts = ->
+  observer.getInstalledKeyboardLayouts()
+
 onDidChangeCurrentKeyboardLayout = (callback) ->
   emitter.on 'did-change-current-keyboard-layout', callback
 
@@ -14,4 +17,4 @@ observeCurrentKeyboardLayout = (callback) ->
   callback(getCurrentKeyboardLayout())
   onDidChangeCurrentKeyboardLayout(callback)
 
-module.exports = {getCurrentKeyboardLayout, onDidChangeCurrentKeyboardLayout, observeCurrentKeyboardLayout}
+module.exports = {getCurrentKeyboardLayout, getInstalledKeyboardLayouts, onDidChangeCurrentKeyboardLayout, observeCurrentKeyboardLayout}

--- a/src/keyboard-layout.coffee
+++ b/src/keyboard-layout.coffee
@@ -7,11 +7,13 @@ observer = new KeyboardLayoutObserver -> emitter.emit 'did-change-current-keyboa
 getCurrentKeyboardLayout = ->
   observer.getCurrentKeyboardLayout()
 
-getInstalledKeyboardLayouts = ->
-  rawList = observer.getInstalledKeyboardLayouts()
+getCurrentKeyboardLanguage = ->
+  observer.getCurrentKeyboardLanguage()
+
+getInstalledKeyboardLanguages = ->
+  rawList = observer.getInstalledKeyboardLanguages()
 
   ret = []
-  console.log JSON.stringify(rawList)
   for item in rawList
     continue if ret.indexOf(item) >= 0
     ret.push(item)
@@ -25,4 +27,4 @@ observeCurrentKeyboardLayout = (callback) ->
   callback(getCurrentKeyboardLayout())
   onDidChangeCurrentKeyboardLayout(callback)
 
-module.exports = {getCurrentKeyboardLayout, getInstalledKeyboardLayouts, onDidChangeCurrentKeyboardLayout, observeCurrentKeyboardLayout}
+module.exports = {getCurrentKeyboardLayout, getCurrentKeyboardLanguage, getInstalledKeyboardLanguages, onDidChangeCurrentKeyboardLayout, observeCurrentKeyboardLayout}

--- a/src/keyboard-layout.coffee
+++ b/src/keyboard-layout.coffee
@@ -8,7 +8,15 @@ getCurrentKeyboardLayout = ->
   observer.getCurrentKeyboardLayout()
 
 getInstalledKeyboardLayouts = ->
-  observer.getInstalledKeyboardLayouts()
+  rawList = observer.getInstalledKeyboardLayouts()
+
+  ret = []
+  console.log JSON.stringify(rawList)
+  for item in rawList
+    continue if ret.indexOf(item) >= 0
+    ret.push(item)
+
+  ret
 
 onDidChangeCurrentKeyboardLayout = (callback) ->
   emitter.on 'did-change-current-keyboard-layout', callback


### PR DESCRIPTION
This PR adds two new methods to Keyboard Layout:

* `getCurrentKeyboardLanguage()` - returns a String representing the BCP 47 language code for the currently active keyboard (i.e. 'en')
* `getInstalledKeyboardLanguages()` - returns an Array of BCP 47 language codes representing the available languages for the active keyboard layouts (i.e. the ones the user would possibly type in)


### Example: 

```coffee
kl = require('./src/keyboard-layout')

kl.getCurrentKeyboardLayout()
>>> 'com.apple.keylayout.US'

kl.getCurrentKeyboardLanguage()
>>> 'en'

kl.getInstalledKeyboardLanguages()
[ 'en', 'de', 'ja' ]
```