### PR TITLE
warnings as error from true to false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-lib/
 .DS_Store
 npm-debug.log
 *.swp

--- a/binding.gyp
+++ b/binding.gyp
@@ -21,7 +21,7 @@
           'msvs_settings': {
             'VCCLCompilerTool': {
               'ExceptionHandling': 1, # /EHsc
-              'WarnAsError': 'true',
+              'WarnAsError': 'false',
             },
           },
           'msvs_disabled_warnings': [

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -1,0 +1,50 @@
+(function() {
+  var Emitter, KeyboardLayoutObserver, emitter, getCurrentKeyboardLanguage, getCurrentKeyboardLayout, getInstalledKeyboardLanguages, observeCurrentKeyboardLayout, observer, onDidChangeCurrentKeyboardLayout;
+
+  Emitter = require('event-kit').Emitter;
+
+  KeyboardLayoutObserver = require('../build/Release/keyboard-layout-observer.node').KeyboardLayoutObserver;
+
+  emitter = new Emitter;
+
+  observer = new KeyboardLayoutObserver(function() {
+    return emitter.emit('did-change-current-keyboard-layout', getCurrentKeyboardLayout());
+  });
+
+  getCurrentKeyboardLayout = function() {
+    return observer.getCurrentKeyboardLayout();
+  };
+
+  getCurrentKeyboardLanguage = function() {
+    return observer.getCurrentKeyboardLanguage();
+  };
+
+  getInstalledKeyboardLanguages = function() {
+    var language, languages, _i, _len, _ref;
+    languages = {};
+    _ref = observer.getInstalledKeyboardLanguages();
+    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+      language = _ref[_i];
+      languages[language] = true;
+    }
+    return Object.keys(languages);
+  };
+
+  onDidChangeCurrentKeyboardLayout = function(callback) {
+    return emitter.on('did-change-current-keyboard-layout', callback);
+  };
+
+  observeCurrentKeyboardLayout = function(callback) {
+    callback(getCurrentKeyboardLayout());
+    return onDidChangeCurrentKeyboardLayout(callback);
+  };
+
+  module.exports = {
+    getCurrentKeyboardLayout: getCurrentKeyboardLayout,
+    getCurrentKeyboardLanguage: getCurrentKeyboardLanguage,
+    getInstalledKeyboardLanguages: getInstalledKeyboardLanguages,
+    onDidChangeCurrentKeyboardLayout: onDidChangeCurrentKeyboardLayout,
+    observeCurrentKeyboardLayout: observeCurrentKeyboardLayout
+  };
+
+}).call(this);


### PR DESCRIPTION
I simply set errors and warnings to true for now.
It looks like the warning is around 64-bit pointers from getting cast to 32 bit pointers at lines 92 and 111.

Everything appears to work despite the warnings.

```
..\src\keyboard-layout-observer-windows.cc(92): warning C4311: 'type cast': pointer truncation from 'HKL' to 'UINT' [C:\Code\N1\node_modules\
keyboard-layout\build\keyboard-layout-observer.vcxproj]
..\src\keyboard-layout-observer-windows.cc(92): warning C4302: 'type cast': truncation from 'HKL' to 'UINT' [C:\Code\N1\node_modules\keyboard
-layout\build\keyboard-layout-observer.vcxproj]
..\src\keyboard-layout-observer-windows.cc(111): warning C4311: 'type cast': pointer truncation from 'HKL' to 'UINT' [C:\Code\N1\node_modules
\keyboard-layout\build\keyboard-layout-observer.vcxproj]
..\src\keyboard-layout-observer-windows.cc(111): warning C4302: 'type cast': truncation from 'HKL' to 'UINT' [C:\Code\N1\node_modules\keyboar
d-layout\build\keyboard-layout-observer.vcxproj]
```
