### PR TITLE
Fix crash in keyboard-layout on Linux

### DIFF
--- a/src/keyboard-layout.coffee
+++ b/src/keyboard-layout.coffee
@@ -16,7 +16,7 @@ getInstalledKeyboardLanguages = ->
   # and Katakana, both would correspond to the language "ja"), so we need to
   # dedupe this list.
   languages = {}
-  for language in observer.getInstalledKeyboardLanguages()
+  for language in (observer.getInstalledKeyboardLanguages() or [])
     languages[language] = true
   Object.keys(languages)
 


### PR DESCRIPTION
This doesn't implement the method, but at least stops us from blowing up when we call it