### PR TITLE
Fix build for VS2015

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -28,8 +28,11 @@
             4018,  # signed/unsigned mismatch
             4244,  # conversion from 'type1' to 'type2', possible loss of data
             4267,  # conversion from 'size_t' to 'type', possible loss of data
+            4302,  # 'type cast': truncation from 'HKL' to 'UINT'
+            4311,  # 'type cast': pointer truncation from 'HKL' to 'UINT'
             4530,  # C++ exception handler used, but unwind semantics are not enabled
             4506,  # no definition for inline function
+            4577,  # 'noexcept' used with no exception handling mode specified
             4996,  # function was declared deprecated
           ],
         }],  # OS=="win"

--- a/src/keyboard-layout-observer-windows.cc
+++ b/src/keyboard-layout-observer-windows.cc
@@ -4,6 +4,8 @@
 #undef WINVER
 #define WINVER 0x0601
 
+#pragma warning(disable: 4311 4302)
+
 #include "keyboard-layout-observer.h"
 
 #include <string>

--- a/src/keyboard-layout-observer-windows.cc
+++ b/src/keyboard-layout-observer-windows.cc
@@ -4,8 +4,6 @@
 #undef WINVER
 #define WINVER 0x0601
 
-#pragma warning(disable: 4311 4302)
-
 #include "keyboard-layout-observer.h"
 
 #include <string>


### PR DESCRIPTION
This PR fixes #11 without turning off warnings as errors. We just need to ignore the two pointer truncation warnings and the other one :sparkles: magically :sparkles: goes away.