### PR TITLE
Upgrade AppVeyor to node LTS

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm install -g npm@lts
   - npm install
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  nodejs_version: "0.10"
+  nodejs_version: "LTS"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
Refs the failure in #14 

Fixes the following build error:

```
C:\Program Files (x86)\nodejs\node_modules\npm\node_modules\node-gyp\src\win_delay_load_hook.c(34): error C2373: '__pfnDliNotifyHook2': redefinition; different type modifiers [C:\projects\keyboard-layout\build\keyboard-layout-observer.vcxproj]
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\delayimp.h(134): note: see declaration of '__pfnDliNotifyHook2'
```

/cc @CharlieHess 