### PR TITLE
Support getCurrentKeymap on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
-language: objective-c
+language: node_js
+
+os:
+  - linux
+  - osx
 
 notifications:
   email:
     on_success: never
     on_failure: change
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+script: 'npm test'
 
 git:
-  depth: 10
-
-branches:
-  only:
-    - master
+  depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ os:
   - linux
   - osx
 
+addons:
+  apt:
+    packages:
+      - libx11-dev
+      - libxkbfile-dev
+
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
     - os: linux
       node_js: 6
-      env: CC=clang CXX=clang++ npm_config_clang=1
+      env: DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
     - os: osx
       node_js: 6
 
@@ -15,12 +15,15 @@ addons:
       - libx11-dev
       - libxkbfile-dev
 
-notifications:
-  email:
-    on_success: never
-    on_failure: change
+before_install:
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 
 script: 'npm test'
 
 git:
   depth: 1
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: node_js
 
-node_js: 6
-
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+      node_js: 6
+      env: CC=clang CXX=clang++ npm_config_clang=1
+    - os: osx
+      node_js: 6
 
 addons:
   apt:
     packages:
+      - clang-3.3
       - libx11-dev
       - libxkbfile-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     - os: linux
       node_js: 6
       env: DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
+      before_install:
+        - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
     - os: osx
       node_js: 6
 
@@ -14,9 +16,6 @@ addons:
       - clang-3.3
       - libx11-dev
       - libxkbfile-dev
-
-before_install:
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 
 script: 'npm test'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 
+node_js: 6
+
 os:
   - linux
   - osx

--- a/binding.gyp
+++ b/binding.gyp
@@ -43,6 +43,11 @@
           "sources": [
             "src/keyboard-layout-manager-linux.cc",
           ],
+          "link_settings": {
+            "libraries": [
+              "-lX11", "-lxkbfile"
+            ]
+          }
         }],  # OS=="linux"
       ]
     }

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -4,37 +4,28 @@ const Emitter = require('event-kit').Emitter
 const KeyboardLayoutManager = require('../build/Release/keyboard-layout-manager.node')
 
 const emitter = new Emitter()
-
-let currentKeymap = null
-let currentKeyboardLayout = null
-let currentKeyboardLanguage = null
+const keymapsByLayoutName = new Map()
 
 const manager = new KeyboardLayoutManager(() => {
-  currentKeymap = null
-  currentKeyboardLayout = null
-  currentKeyboardLanguage = null
   emitter.emit('did-change-current-keyboard-layout', getCurrentKeyboardLayout())
 })
 
 function getCurrentKeymap () {
+  const currentLayout = getCurrentKeyboardLayout()
+  let currentKeymap = keymapsByLayoutName.get(currentLayout)
   if (!currentKeymap) {
     currentKeymap = manager.getCurrentKeymap()
+    keymapsByLayoutName.set(currentLayout, currentKeymap)
   }
   return currentKeymap
 }
 
 function getCurrentKeyboardLayout () {
-  if (!currentKeyboardLayout) {
-    currentKeyboardLayout = manager.getCurrentKeyboardLayout()
-  }
-  return currentKeyboardLayout
+   return manager.getCurrentKeyboardLayout()
 }
 
 function getCurrentKeyboardLanguage () {
-  if (!currentKeyboardLanguage) {
-    currentKeyboardLanguage = manager.getCurrentKeyboardLanguage()
-  }
-  return currentKeyboardLanguage
+  return manager.getCurrentKeyboardLanguage()
 }
 
 function getInstalledKeyboardLanguages () {

--- a/spec/keyboard-layout-spec.js
+++ b/spec/keyboard-layout-spec.js
@@ -49,51 +49,68 @@ describe('Keyboard Layout', () => {
         }
       })
     })
+
+    describe('.getCurrentKeyboardLayout()', () => {
+      it('returns the current keyboard layout', () => {
+        const layout = KeyboardLayout.getCurrentKeyboardLayout()
+        expect(typeof layout).toBe('string')
+        expect(layout.length).toBeGreaterThan(0)
+      })
+    })
+
+    describe('.observeCurrentKeyboardLayout(callback)', () => {
+      it('calls back immediately with the current keyboard layout', () => {
+        const callback = jasmine.createSpy('observeCurrentKeyboardLayout')
+        const disposable = KeyboardLayout.observeCurrentKeyboardLayout(callback)
+        disposable.dispose()
+        expect(callback.callCount).toBe(1)
+        const layout = callback.argsForCall[0][0]
+        expect(typeof layout).toBe('string')
+        expect(layout.length).toBeGreaterThan(0)
+      })
+    })
+
+    describe('.getCurrentKeyboardLanguage()', () => {
+      it('returns the current keyboard language', () => {
+        const language = KeyboardLayout.getCurrentKeyboardLanguage()
+        expect(typeof language).toBe('string')
+        expect(language.length).toBeGreaterThan(0)
+      })
+    })
+
+    describe('.getInstalledKeyboardLanguages()', () => {
+      it('returns an array of string keyboard languages', () => {
+        const languages = KeyboardLayout.getInstalledKeyboardLanguages()
+        expect(Array.isArray(languages)).toBe(true)
+
+        if (!(process.platform === 'win32' && process.env.CI)) {
+          expect(languages.length).toBeGreaterThan(0)
+        }
+
+        return (() => {
+          for (const language of languages) {
+            expect(typeof language).toBe('string')
+            expect(language.length).toBeGreaterThan(0)
+          }
+        })()
+      })
+    })
   }
 
-  describe('.getCurrentKeyboardLayout()', () => {
-    it('returns the current keyboard layout', () => {
-      const layout = KeyboardLayout.getCurrentKeyboardLayout()
-      expect(typeof layout).toBe('string')
-      expect(layout.length).toBeGreaterThan(0)
+  // Smoke tests on Linux
+  if (process.platform === 'linux') {
+    describe('.getCurrentKeymap()', function () {
+      it('returns a keymap with unmodified and shift-modified keys without blowing up (basic smoke test)', function () {
+        const keymap = KeyboardLayout.getCurrentKeymap()
+        expect(keymap.KeyG.unmodified).toBeDefined()
+        expect(keymap.KeyG.withShift).toBeDefined()
+      })
     })
-  })
 
-  describe('.observeCurrentKeyboardLayout(callback)', () => {
-    it('calls back immediately with the current keyboard layout', () => {
-      const callback = jasmine.createSpy('observeCurrentKeyboardLayout')
-      const disposable = KeyboardLayout.observeCurrentKeyboardLayout(callback)
-      disposable.dispose()
-      expect(callback.callCount).toBe(1)
-      const layout = callback.argsForCall[0][0]
-      expect(typeof layout).toBe('string')
-      expect(layout.length).toBeGreaterThan(0)
+    describe('.getCurrentKeyboardLayout()', function () {
+      it('returns an identifier for the current keyboard layout (basic smoke test)', function () {
+        expect(KeyboardLayout.getCurrentKeyboardLayout()).toBeDefined()
+      })
     })
-  })
-
-  describe('.getCurrentKeyboardLanguage()', () => {
-    it('returns the current keyboard language', () => {
-      const language = KeyboardLayout.getCurrentKeyboardLanguage()
-      expect(typeof language).toBe('string')
-      expect(language.length).toBeGreaterThan(0)
-    })
-  })
-
-  describe('.getInstalledKeyboardLanguages()', () => {
-    it('returns an array of string keyboard languages', () => {
-      const languages = KeyboardLayout.getInstalledKeyboardLanguages()
-      expect(Array.isArray(languages)).toBe(true)
-
-      if (!(process.platform === 'win32' && process.env.CI)) {
-        expect(languages.length).toBeGreaterThan(0)
-      }
-
-      return (() => {
-        for (const language of languages) {
-          expect(typeof language).toBe('string')
-          expect(language.length).toBeGreaterThan(0)
-        }
-      })()
-    })
-  })
+  }
 })

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -1,16 +1,19 @@
 #include "keyboard-layout-manager.h"
 
-using namespace v8;
+#include <X11/XKBlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/XKBrules.h>
 
-void KeyboardLayoutManager::Init(Handle<Object> exports, Handle<Object> module) {
+void KeyboardLayoutManager::Init(v8::Handle<v8::Object> exports, v8::Handle<v8::Object> module) {
   Nan::HandleScope scope;
-  Local<FunctionTemplate> newTemplate = Nan::New<FunctionTemplate>(KeyboardLayoutManager::New);
-  newTemplate->SetClassName(Nan::New<String>("KeyboardLayoutManager").ToLocalChecked());
+  v8::Local<v8::FunctionTemplate> newTemplate = Nan::New<v8::FunctionTemplate>(KeyboardLayoutManager::New);
+  newTemplate->SetClassName(Nan::New<v8::String>("KeyboardLayoutManager").ToLocalChecked());
   newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
-  Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
+  v8::Local<v8::ObjectTemplate> proto = newTemplate->PrototypeTemplate();
   Nan::SetMethod(proto, "getCurrentKeyboardLayout", KeyboardLayoutManager::GetCurrentKeyboardLayout);
   Nan::SetMethod(proto, "getCurrentKeyboardLanguage", KeyboardLayoutManager::GetCurrentKeyboardLayout); // NB:  Intentionally mapped to same stub
   Nan::SetMethod(proto, "getInstalledKeyboardLanguages", KeyboardLayoutManager::GetInstalledKeyboardLanguages);
+  Nan::SetMethod(proto, "getCurrentKeymap", KeyboardLayoutManager::GetCurrentKeymap);
   module->Set(Nan::New("exports").ToLocalChecked(), newTemplate->GetFunction());
 }
 
@@ -19,7 +22,7 @@ NODE_MODULE(keyboard_layout_manager, KeyboardLayoutManager::Init)
 NAN_METHOD(KeyboardLayoutManager::New) {
   Nan::HandleScope scope;
 
-  Local<Function> callbackHandle = info[0].As<Function>();
+  v8::Local<v8::Function> callbackHandle = info[0].As<v8::Function>();
   Nan::Callback *callback = new Nan::Callback(callbackHandle);
 
   KeyboardLayoutManager *manager = new KeyboardLayoutManager(callback);
@@ -28,9 +31,14 @@ NAN_METHOD(KeyboardLayoutManager::New) {
 }
 
 KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback(callback) {
+  xDisplay = XOpenDisplay("");
+  if (!xDisplay) {
+    Nan::ThrowError("Could not connect to X display.");
+  }
 }
 
 KeyboardLayoutManager::~KeyboardLayoutManager() {
+  XCloseDisplay(xDisplay);
   delete callback;
 };
 
@@ -39,6 +47,19 @@ void KeyboardLayoutManager::HandleKeyboardLayoutChanged() {
 
 NAN_METHOD(KeyboardLayoutManager::GetCurrentKeyboardLayout) {
   Nan::HandleScope scope;
+  KeyboardLayoutManager* manager = Nan::ObjectWrap::Unwrap<KeyboardLayoutManager>(info.Holder());
+  v8::Handle<v8::Value> result;
+
+  XkbRF_VarDefsRec vdr;
+  char *tmp = NULL;
+  if (XkbRF_GetNamesProp(manager->xDisplay, &tmp, &vdr) && vdr.layout && vdr.variant) {
+    result = Nan::New<v8::String>(std::string(vdr.layout) + "," + std::string(vdr.variant)).ToLocalChecked();
+  } else {
+    result = Nan::Null();
+  }
+
+  info.GetReturnValue().Set(result);
+
   return;
 }
 
@@ -47,6 +68,65 @@ NAN_METHOD(KeyboardLayoutManager::GetInstalledKeyboardLanguages) {
   return;
 }
 
+struct KeycodeMapEntry {
+  uint xkbKeycode;
+  const char *dom3Code;
+};
+
+#define USB_KEYMAP_DECLARATION static const KeycodeMapEntry keyCodeMap[] =
+#define USB_KEYMAP(usb, evdev, xkb, win, mac, code, id) {xkb, code}
+
+#include "keycode_converter_data.inc"
+
+v8::Local<v8::Value> CharacterForNativeCode(XKeyEvent *keyEvent, uint xkbKeycode, uint state) {
+  keyEvent->keycode = xkbKeycode;
+  keyEvent->state = state;
+
+  char characters[2];
+  int count = XLookupString(keyEvent, characters, 2, NULL, NULL);
+
+  if (count > 0 && !std::iscntrl(characters[0])) {
+    return Nan::New<v8::String>(characters, count).ToLocalChecked();
+  } else {
+    return Nan::Null();
+  }
+}
+
 NAN_METHOD(KeyboardLayoutManager::GetCurrentKeymap) {
-  Nan::ThrowError("getCurrentKeymap is not implemented on Linux");
+  v8::Handle<v8::Object> result = Nan::New<v8::Object>();
+  KeyboardLayoutManager* manager = Nan::ObjectWrap::Unwrap<KeyboardLayoutManager>(info.Holder());
+  v8::Local<v8::String> unmodifiedKey = Nan::New("unmodified").ToLocalChecked();
+  v8::Local<v8::String> withShiftKey = Nan::New("withShift").ToLocalChecked();
+
+  // Clear cached keymap
+  XMappingEvent eventMap = {MappingNotify, 0, false, manager->xDisplay, 0, MappingKeyboard, 0, 0};
+  XRefreshKeyboardMapping(&eventMap);
+
+  // Set up an event to reuse across CharacterForNativeCode calls
+  XEvent event;
+  memset(&event, 0, sizeof(XEvent));
+  XKeyEvent* keyEvent = &event.xkey;
+  keyEvent->display = manager->xDisplay;
+  keyEvent->type = KeyPress;
+
+  size_t keyCodeMapSize = sizeof(keyCodeMap) / sizeof(keyCodeMap[0]);
+  for (size_t i = 0; i < keyCodeMapSize; i++) {
+    const char *dom3Code = keyCodeMap[i].dom3Code;
+    uint xkbKeycode = keyCodeMap[i].xkbKeycode;
+
+    if (dom3Code && xkbKeycode > 0x0000) {
+      v8::Local<v8::String> dom3CodeKey = Nan::New(dom3Code).ToLocalChecked();
+      v8::Local<v8::Value> unmodified = CharacterForNativeCode(keyEvent, xkbKeycode, 0);
+      v8::Local<v8::Value> withShift = CharacterForNativeCode(keyEvent, xkbKeycode, ShiftMask);
+
+      if (unmodified->IsString() || withShift->IsString()) {
+        v8::Local<v8::Object> entry = Nan::New<v8::Object>();
+        entry->Set(unmodifiedKey, unmodified);
+        entry->Set(withShiftKey, withShift);
+        result->Set(dom3CodeKey, entry);
+      }
+    }
+  }
+
+  info.GetReturnValue().Set(result);
 }

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -3,11 +3,13 @@
 
 #include "nan.h"
 
-using namespace v8;  // NOLINT
+#ifdef __linux__
+#include <X11/Xlib.h>
+#endif // __linux__
 
 class KeyboardLayoutManager : public Nan::ObjectWrap {
  public:
-  static void Init(Handle<Object> target, Handle<Object> module);
+  static void Init(v8::Handle<v8::Object> target, v8::Handle<v8::Object> module);
   void HandleKeyboardLayoutChanged();
 
  private:
@@ -18,6 +20,10 @@ class KeyboardLayoutManager : public Nan::ObjectWrap {
   static NAN_METHOD(GetCurrentKeyboardLanguage);
   static NAN_METHOD(GetInstalledKeyboardLanguages);
   static NAN_METHOD(GetCurrentKeymap);
+
+#ifdef __linux__
+  Display *xDisplay;
+#endif
 
   Nan::Callback *callback;
 };


### PR DESCRIPTION
It only returns a subset of characters (`unmodified` and `withShift`) because that's all we needed to work around a Chrome bug in Atom and getting the others seemed complicated. Still working on a green Travis build.

/cc @as-cii 