### PR TITLE
Use `std::iswcntrl` instead of `std::iscntrl` on Windows

### DIFF
--- a/src/keyboard-layout-manager-windows.cc
+++ b/src/keyboard-layout-manager-windows.cc
@@ -9,7 +9,7 @@
 #include "keyboard-layout-manager.h"
 
 #include <string>
-#include <cctype>
+#include <cwctype>
 #include <windows.h>
 
 using namespace v8;
@@ -151,7 +151,7 @@ Local<Value> CharacterForNativeCode(HKL keyboardLayout, UINT keyCode, UINT scanC
   wchar_t characters[5];
   int count = ToUnicodeEx(keyCode, scanCode, keyboardState, characters, 5, 0, keyboardLayout);
 
-  if (count > 0 && !std::iscntrl(characters[0])) {
+  if (count > 0 && !std::iswcntrl(characters[0])) {
     return Nan::New<String>(reinterpret_cast<const uint16_t *>(characters), count).ToLocalChecked();
   } else {
     return Nan::Null();


### PR DESCRIPTION
Refs: https://github.com/atom/atom/issues/13296

As specified in http://en.cppreference.com/w/cpp/string/byte/iscntrl, passing a character that cannot be represented as an `unsigned char` can cause undefined behavior. The characters that are returned from `ToUnicodeEx` are *wide characters* and, therefore, calling `std::iscntrl` is not appropriate when dealing with non-latin languages.

On 32-bit builds of Atom, this was causing the Saudi Arabian keyboards keymap to not list many key codes (e.g. `KeyA`, `KeyS`, etc.), thus making the calling code (atom-keymap) throw errors and behave weirdly.

/cc: @atom/maintainers 