### PR TITLE
On Linux, use `XwcLookupString` to support a wider range of languages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
       env: DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
       before_install:
         - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
+      before_script:
+        - "./node_modules/.bin/electron &" # this opens a new window in the background, so that `XGetInputFocus` works in a xvfb headless environment.
     - os: osx
       node_js: 6
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "nan": "^2.0.0"
   },
   "devDependencies": {
+    "electron": "^1.4.13",
     "jasmine-focused": "^1.0.4"
   }
 }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -35,16 +35,19 @@ KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback
   xDisplay = XOpenDisplay("");
   if (!xDisplay) {
     Nan::ThrowError("Could not connect to X display.");
+    return;
   }
 
   XIM xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
   if (!xInputMethod) {
     Nan::ThrowError("Could not create an input method.");
+    return;
   }
 
   XIMStyles* styles = 0;
   if (XGetIMValues(xInputMethod, XNQueryInputStyle, &styles, NULL) || !styles) {
     Nan::ThrowError("Could not retrieve input styles.");
+    return;
   }
 
   XIMStyle bestMatchStyle = 0;
@@ -59,6 +62,7 @@ KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback
   XFree(styles);
   if (!bestMatchStyle) {
     Nan::ThrowError("Could not retrieve input styles.");
+    return;
   }
 
   Window window;
@@ -66,6 +70,7 @@ KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback
   XGetInputFocus(xDisplay, &window, &revert_to);
   if (!window) {
     Nan::ThrowError("Could not find foreground window.");
+    return;
   }
 
   xInputContext = XCreateIC(
@@ -74,6 +79,7 @@ KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback
   );
   if (!xInputContext) {
     Nan::ThrowError("Could not create an input context.");
+    return;
   }
 }
 

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -38,7 +38,7 @@ KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback
     return;
   }
 
-  XIM xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
+  xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
   if (!xInputMethod) {
     Nan::ThrowError("Could not create an input method.");
     return;
@@ -85,6 +85,7 @@ KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback
 
 KeyboardLayoutManager::~KeyboardLayoutManager() {
   XDestroyIC(xInputContext);
+  XCloseIM(xInputMethod);
   XCloseDisplay(xDisplay);
   delete callback;
 };

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -100,8 +100,12 @@ NAN_METHOD(KeyboardLayoutManager::GetCurrentKeyboardLayout) {
 
   XkbRF_VarDefsRec vdr;
   char *tmp = NULL;
-  if (XkbRF_GetNamesProp(manager->xDisplay, &tmp, &vdr) && vdr.layout && vdr.variant) {
-    result = Nan::New<v8::String>(std::string(vdr.layout) + "," + std::string(vdr.variant)).ToLocalChecked();
+  if (XkbRF_GetNamesProp(manager->xDisplay, &tmp, &vdr) && vdr.layout) {
+    if (vdr.variant) {
+      result = Nan::New<v8::String>(std::string(vdr.layout) + "," + std::string(vdr.variant)).ToLocalChecked();
+    } else {
+      result = Nan::New<v8::String>(std::string(vdr.layout)).ToLocalChecked();
+    }
   } else {
     result = Nan::Null();
   }

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -23,6 +23,7 @@ class KeyboardLayoutManager : public Nan::ObjectWrap {
 
 #ifdef __linux__
   Display *xDisplay;
+  XIC xInputContext;
 #endif
 
   Nan::Callback *callback;

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -24,6 +24,7 @@ class KeyboardLayoutManager : public Nan::ObjectWrap {
 #ifdef __linux__
   Display *xDisplay;
   XIC xInputContext;
+  XIM xInputMethod;
 #endif
 
   Nan::Callback *callback;


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/13296.

`XLookupString` returns an array of `char`s, which makes it unsuitable for languages that use a larger character range to represent their glyphs. `XwcLookupString`, on the other hand, returns an array of `wchar_t`: this is more consistent with what we do for macOS and Windows and seems the right solution for Linux as well.

@Ben3eeE @ungb: it would be awesome if you could help me ensure this pull request doesn't introduce any regression on Linux. I performed some basic testing on Ubuntu but I'd ❤️ to get your feedback as well.

/cc: @atom/core 