### PR TITLE
Fix getting the current keymap on GNOME-like systems when multiple input languages are available

### DIFF
--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -53,7 +53,9 @@ NAN_METHOD(KeyboardLayoutManager::GetCurrentKeyboardLayout) {
   XkbRF_VarDefsRec vdr;
   char *tmp = NULL;
   if (XkbRF_GetNamesProp(manager->xDisplay, &tmp, &vdr) && vdr.layout && vdr.variant) {
-    result = Nan::New<v8::String>(std::string(vdr.layout) + "," + std::string(vdr.variant)).ToLocalChecked();
+    XkbStateRec xkbState;
+    XkbGetState(manager->xDisplay, XkbUseCoreKbd, &xkbState);
+    result = Nan::New<v8::String>(std::string(vdr.layout) + "," + std::string(vdr.variant) + " [" + std::to_string(xkbState.group) + "]").ToLocalChecked();
   } else {
     result = Nan::Null();
   }

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -102,6 +102,15 @@ NAN_METHOD(KeyboardLayoutManager::GetCurrentKeymap) {
   XMappingEvent eventMap = {MappingNotify, 0, false, manager->xDisplay, 0, MappingKeyboard, 0, 0};
   XRefreshKeyboardMapping(&eventMap);
 
+  XkbStateRec xkbState;
+  XkbGetState(manager->xDisplay, XkbUseCoreKbd, &xkbState);
+  uint keyboardBaseState = 0x0000;
+  if (xkbState.group == 1) {
+    keyboardBaseState = 0x2000;
+  } else if (xkbState.group == 2) {
+    keyboardBaseState = 0x4000;
+  }
+
   // Set up an event to reuse across CharacterForNativeCode calls
   XEvent event;
   memset(&event, 0, sizeof(XEvent));
@@ -116,8 +125,8 @@ NAN_METHOD(KeyboardLayoutManager::GetCurrentKeymap) {
 
     if (dom3Code && xkbKeycode > 0x0000) {
       v8::Local<v8::String> dom3CodeKey = Nan::New(dom3Code).ToLocalChecked();
-      v8::Local<v8::Value> unmodified = CharacterForNativeCode(keyEvent, xkbKeycode, 0);
-      v8::Local<v8::Value> withShift = CharacterForNativeCode(keyEvent, xkbKeycode, ShiftMask);
+      v8::Local<v8::Value> unmodified = CharacterForNativeCode(keyEvent, xkbKeycode, keyboardBaseState);
+      v8::Local<v8::Value> withShift = CharacterForNativeCode(keyEvent, xkbKeycode, keyboardBaseState | ShiftMask);
 
       if (unmodified->IsString() || withShift->IsString()) {
         v8::Local<v8::Object> entry = Nan::New<v8::Object>();


### PR DESCRIPTION
Back in https://github.com/atom/atom-keymap/pull/193 we shipped an improvement that allowed us to rely less on the X11 native APIs to get information about the active keymap. However, quoting an excerpt of that issue:

> There might still be issues when holding <kbd>AltGr</kbd> and other modifier keys at the same time, as in that case we [retrieve information from X11](https://github.com/atom/atom-keymap/blob/e7d35a17c82081d178cc88e094d2daf1f7ba1735/src/helpers.coffee#L182-L186) to fall back to the non-alt-modified character, and that can cause issues on [some GNOME-based operating systems](https://github.com/atom/atom/issues/13170).

Moreover, even if we decided to get rid of the <kbd>AltGr</kbd> path altogether (as proposed in https://github.com/atom/atom/issues/13131 and implemented in https://github.com/atom/atom-keymap/issues/201), we would still need to detect whether the active layout is non-latin in order to replace the pressed keystroke with a US equivalent character. This motivated @nathansobo and me to try to understand what was going on exactly on GNOME and try to fix it once for all.

After finding a tool named [xkblayout-state](https://github.com/nonpop/xkblayout-state) and toying around with the `xev` command line utility, we discovered that GNOME systems store two pieces of information that are useful to detect what's the active layout at a given time:

1. The active language triplet. For example, if a user adds `Italian`, `US`, `Russian`, `Czech`, `Arabic` and `Polish`, the active language triplet will be either (`Italian, US, Russian`) or (`Czech, Arabic, Polish`).
2. The active language index into that triplet. Continuing our example above, if the user selects `Italian` or `Czech` the index will be `0`. It follows that `US` and `Arabic` will have an index equal to `1`, and `Russian` and `Polish` an index equal to `2`.

With this information we are now able to supply the correct data to `XLookupString` to get back the right answer: in facts, while 1) is completely transparent to the users of the API, 2) can be read via `XkbGetState` and passed as a keyboard modifier state when looking up the string (along with the shift key mask, if necessary).

This pull request improves also `KeyboardLayoutManager::GetCurrentKeyboardLayout`, which now includes 2) in the returned string (this will ensure keymap caching works correctly when switching to a language that belongs to the same triplet). For example, when selecting `Italian` we will now return `it, us, ru [0]` and, similarly, when selecting `Russian` we will now return `it, us, ru [2]`.

For some reason, testing this pull request by using the APIs via a `node` REPL doesn't work as expected. I suspect this is due to the fact that the native APIs aren't called from a GUI, but it shouldn't be an issue since we will always call them from Atom windows.

@ungb @Ben3eeE: I have tested this works fine on a standard Ubuntu distro and on a GNOME based one, but it would be great if you could help us ensure we are not introducing any regression with this. ❤️

/cc: @atom/core 