### PR TITLE
Don't use `XwcLookupString` when no window is open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
       env: DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
       before_install:
         - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
-      before_script:
-        - "./node_modules/.bin/electron &" # this opens a new window in the background, so that `XGetInputFocus` works in a xvfb headless environment.
     - os: osx
       node_js: 6
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "nan": "^2.0.0"
   },
   "devDependencies": {
-    "electron": "^1.4.13",
     "jasmine-focused": "^1.0.4"
   }
 }


### PR DESCRIPTION
`XwcLookupString` requires at least one window to be open in order to work correctly. Headless systems like CI servers, however, often start without any window open, making this library unusable when, for example, testing it on Travis.

Previously we circumvented this problem by manually opening a window before running the tests. However, since this library will be used indirectly by third party packages (where tests get run on an infrastructure that we don't control), with this pull request we are providing a graceful fallback to `XLookupString` whenever a window cannot be detected.

/cc: @nathansobo 