### PR TITLE
Degrade gracefully to `XLookupString` when no input context can be found

### DIFF
--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -32,7 +32,7 @@ NAN_METHOD(KeyboardLayoutManager::New) {
   return;
 }
 
-KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback{callback}, xInputContext{nullptr} {
+KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : xInputContext{nullptr}, callback{callback} {
   xDisplay = XOpenDisplay("");
   if (!xDisplay) {
     Nan::ThrowError("Could not connect to X display.");

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -32,7 +32,7 @@ NAN_METHOD(KeyboardLayoutManager::New) {
   return;
 }
 
-KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback(callback) {
+KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback{callback}, xInputContext{nullptr} {
   xDisplay = XOpenDisplay("");
   if (!xDisplay) {
     Nan::ThrowError("Could not connect to X display.");
@@ -41,13 +41,11 @@ KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback
 
   xInputMethod = XOpenIM(xDisplay, 0, 0, 0);
   if (!xInputMethod) {
-    Nan::ThrowError("Could not create an input method.");
     return;
   }
 
   XIMStyles* styles = 0;
   if (XGetIMValues(xInputMethod, XNQueryInputStyle, &styles, NULL) || !styles) {
-    Nan::ThrowError("Could not retrieve input styles.");
     return;
   }
 
@@ -62,7 +60,6 @@ KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback
   }
   XFree(styles);
   if (!bestMatchStyle) {
-    Nan::ThrowError("Could not retrieve input styles.");
     return;
   }
 
@@ -74,8 +71,6 @@ KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback
       xInputMethod, XNInputStyle, bestMatchStyle, XNClientWindow, window,
       XNFocusWindow, window, NULL
     );
-  } else {
-    xInputContext = nullptr;
   }
 }
 
@@ -140,7 +135,9 @@ v8::Local<v8::Value> CharacterForNativeCode(XIC xInputContext, XKeyEvent *keyEve
     } else {
       return Nan::Null();
     }
-  } else { // fallback for headless systems
+  } else {
+    // Graceful fallback for systems where no window is open or no input context
+    // can be found.
     char characters[2];
     int count = XLookupString(keyEvent, characters, 2, NULL, NULL);
     if (count > 0 && !std::iscntrl(characters[0])) {

--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -32,7 +32,7 @@ NAN_METHOD(KeyboardLayoutManager::New) {
   return;
 }
 
-KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : xInputContext{nullptr}, callback{callback} {
+KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : xInputContext{nullptr}, xInputMethod{nullptr}, callback{callback} {
   xDisplay = XOpenDisplay("");
   if (!xDisplay) {
     Nan::ThrowError("Could not connect to X display.");
@@ -75,8 +75,14 @@ KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : xInputCo
 }
 
 KeyboardLayoutManager::~KeyboardLayoutManager() {
-  XDestroyIC(xInputContext);
-  XCloseIM(xInputMethod);
+  if (xInputContext) {
+    XDestroyIC(xInputContext);
+  }
+
+  if (xInputMethod) {
+    XCloseIM(xInputMethod);
+  }
+
   XCloseDisplay(xDisplay);
   delete callback;
 };


### PR DESCRIPTION
Refs: https://github.com/atom/atom/issues/13785

Instead of throwing an error, with this pull request we will simply fall back to `XLookupString` so that Atom can still be used on systems where an input context can't be found. Interestingly, other popular programs (https://github.com/mpv-player/mpv/blob/master/video/out/x11_common.c#L583-L585) employ a similar technique and I believe we should do the same.

@ungb: it'd be great if we could reproduce the aforementioned issue on Linux and make sure this pull request fixes it.

/cc: @maxbrunsfeld and @nathansobo