### PR TITLE
Skip translating dead keys on Windows for custom layouts

### DIFF
--- a/src/keyboard-layout-manager-windows.cc
+++ b/src/keyboard-layout-manager-windows.cc
@@ -169,9 +169,7 @@ Local<Value> CharacterForNativeCode(HKL keyboardLayout, UINT keyCode, UINT scanC
 
     // Don't translate dead keys
     return Nan::Null();
-  }
-
-  if (count > 0 && !std::iswcntrl(characters[0])) {
+  } else if (count > 0 && !std::iswcntrl(characters[0])) {
     return Nan::New<String>(reinterpret_cast<const uint16_t *>(characters), count).ToLocalChecked();
   } else {
     return Nan::Null();


### PR DESCRIPTION
### Description of the Change

Certain keyboard layouts have dead keys accessible on `AltGraph` or `Shift-AltGraph` and the check in place to skip dead keys does not account for modifier state. This adds a check for this to clear the kernel-mode keyboard buffer when dead keys are found so that subsequent keys are not affected by dead keys and the keymap is generated correctly for these custom layouts.

### Alternate Designs

Instead of building the keymap as a result of a keystroke we could listen to the event for changing keyboard layout and build the keymap. This would enable us to map dead keys on Windows again without reintroducing https://github.com/atom/atom/issues/13263. There is a [branch](https://github.com/atom/keyboard-layout/tree/handle-dead-keys-correctly) experimenting with this alternative design but it is not ready yet.

### Benefits

Workaround for https://github.com/atom/atom-keymap/issues/188

### Possible Drawbacks

* This might reintroduce https://github.com/atom/atom/issues/13263 for these layouts. Other layouts should not be affected because the other check is unchanged.
* I never tested this in Atom because the module refused to link. I did test it in node by requiring keyboard-layout and printing the generated keymap. So there might be some issues introduced by this that I didn't catch.

### Applicable Issues

Fixes https://github.com/atom/atom-keymap/issues/188
https://github.com/atom/atom/issues/13263
https://github.com/Ben3eeE/atom-honor-altgraph/issues/1

