### PR TITLE
Bump event-kit to version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   ],
   "dependencies": {
-    "event-kit": "^1.0.0",
+    "event-kit": "^2.0.0",
     "nan": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We discovered that keyboard-layout is using old version for event-kit (1.x.y) which contains a lot of other sub-dependencies.

By bumping to version 2.3.0 we would remove these unused dependencies and have a much cleaner dependency graph. Also would help MS software to bundle easier the spellchecker provided by @paulcbetts 