### PR TITLE
fix: Handle -> Local for node 12 compat

### DIFF
--- a/src/keyboard-layout-manager-linux.cc
+++ b/src/keyboard-layout-manager-linux.cc
@@ -6,7 +6,7 @@
 #include <cwctype>
 #include <cctype>
 
-void KeyboardLayoutManager::Init(v8::Handle<v8::Object> exports, v8::Handle<v8::Object> module) {
+void KeyboardLayoutManager::Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
   Nan::HandleScope scope;
   v8::Local<v8::FunctionTemplate> newTemplate = Nan::New<v8::FunctionTemplate>(KeyboardLayoutManager::New);
   newTemplate->SetClassName(Nan::New<v8::String>("KeyboardLayoutManager").ToLocalChecked());

--- a/src/keyboard-layout-manager-mac.mm
+++ b/src/keyboard-layout-manager-mac.mm
@@ -9,7 +9,7 @@
 
 using namespace v8;
 
-void KeyboardLayoutManager::Init(Handle<Object> exports, Handle<Object> module) {
+void KeyboardLayoutManager::Init(Local<Object> exports, Local<Object> module) {
   Nan::HandleScope scope;
   Local<FunctionTemplate> newTemplate = Nan::New<FunctionTemplate>(KeyboardLayoutManager::New);
   newTemplate->SetClassName(Nan::New<String>("KeyboardLayoutManager").ToLocalChecked());
@@ -190,7 +190,7 @@ NAN_METHOD(KeyboardLayoutManager::GetCurrentKeymap) {
 
   const UCKeyboardLayout* keyboardLayout = reinterpret_cast<const UCKeyboardLayout*>(CFDataGetBytePtr(layoutData));
 
-  Handle<Object> result = Nan::New<Object>();
+  Local<Object> result = Nan::New<Object>();
   Local<String> unmodifiedKey = Nan::New("unmodified").ToLocalChecked();
   Local<String> withShiftKey = Nan::New("withShift").ToLocalChecked();
   Local<String> withAltGraphKey = Nan::New("withAltGraph").ToLocalChecked();

--- a/src/keyboard-layout-manager-windows.cc
+++ b/src/keyboard-layout-manager-windows.cc
@@ -40,7 +40,7 @@ HKL GetForegroundWindowHKL() {
   return GetKeyboardLayout(dwThreadId);
 }
 
-void KeyboardLayoutManager::Init(Handle<Object> exports, Handle<Object> module) {
+void KeyboardLayoutManager::Init(Local<Object> exports, Local<Object> module) {
   Nan::HandleScope scope;
   Local<FunctionTemplate> newTemplate = Nan::New<FunctionTemplate>(KeyboardLayoutManager::New);
   newTemplate->SetClassName(Nan::New<String>("KeyboardLayoutManager").ToLocalChecked());
@@ -180,7 +180,7 @@ NAN_METHOD(KeyboardLayoutManager::GetCurrentKeymap) {
   BYTE keyboardState[256];
   HKL keyboardLayout = GetForegroundWindowHKL();
 
-  Handle<Object> result = Nan::New<Object>();
+  Local<Object> result = Nan::New<Object>();
   Local<String> unmodifiedKey = Nan::New("unmodified").ToLocalChecked();
   Local<String> withShiftKey = Nan::New("withShift").ToLocalChecked();
   Local<String> withAltGraphKey = Nan::New("withAltGraph").ToLocalChecked();

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -9,7 +9,7 @@
 
 class KeyboardLayoutManager : public Nan::ObjectWrap {
  public:
-  static void Init(v8::Handle<v8::Object> target, v8::Handle<v8::Object> module);
+  static void Init(v8::Local<v8::Object> target, v8::Local<v8::Object> module);
   void HandleKeyboardLayoutChanged();
 
  private:


### PR DESCRIPTION
This fixes compilation errors on node 12 / electron 5. `v8::Handle` is deprecated and has been removed.