### PR TITLE
 feat: make Context Aware - Supports Node 12 Workers

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,9 @@
   "targets": [
     {
       "target_name": "keyboard-layout-manager",
+      "sources": [
+        "src/keyboard-layout-manager.cc"
+      ],
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         "chrome_headers",

--- a/lib/keyboard-layout.js
+++ b/lib/keyboard-layout.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Emitter = require('event-kit').Emitter
-const KeyboardLayoutManager = require('../build/Release/keyboard-layout-manager.node')
+const { KeyboardLayoutManager } = require('../build/Release/keyboard-layout-manager.node')
 
 const emitter = new Emitter()
 const keymapsByLayoutName = new Map()

--- a/src/keyboard-layout-manager-windows.cc
+++ b/src/keyboard-layout-manager-windows.cc
@@ -40,45 +40,7 @@ HKL GetForegroundWindowHKL() {
   return GetKeyboardLayout(dwThreadId);
 }
 
-void KeyboardLayoutManager::Init(Local<Object> exports, Local<Object> module) {
-  Nan::HandleScope scope;
-
-  // Once Nan supports Node v12, remove this.
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  // End remove after Nan supports Node v12
-
-  Local<FunctionTemplate> newTemplate = Nan::New<FunctionTemplate>(KeyboardLayoutManager::New);
-  newTemplate->SetClassName(Nan::New<String>("KeyboardLayoutManager").ToLocalChecked());
-  newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
-  Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
-
-  Nan::SetMethod(proto, "getCurrentKeyboardLayout", KeyboardLayoutManager::GetCurrentKeyboardLayout);
-  Nan::SetMethod(proto, "getCurrentKeyboardLanguage", KeyboardLayoutManager::GetCurrentKeyboardLanguage);
-  Nan::SetMethod(proto, "getInstalledKeyboardLanguages", KeyboardLayoutManager::GetInstalledKeyboardLanguages);
-  Nan::SetMethod(proto, "getCurrentKeymap", KeyboardLayoutManager::GetCurrentKeymap);
-
-  // Note: Once NAN supports Node v12, change this to:
-  // Nan::Set(module, Nan::New("exports").ToLocalChecked(),
-  //   (Nan::GetFunction(newTemplate)).ToLocalChecked());
-  module->Set(Nan::New("exports").ToLocalChecked(), newTemplate->GetFunction(context).ToLocalChecked());
-}
-
-NODE_MODULE(keyboard_layout_manager, KeyboardLayoutManager::Init)
-
-NAN_METHOD(KeyboardLayoutManager::New) {
-  Nan::HandleScope scope;
-
-  Local<Function> callbackHandle = info[0].As<Function>();
-  Nan::Callback *callback = new Nan::Callback(callbackHandle);
-
-  KeyboardLayoutManager *manager = new KeyboardLayoutManager(callback);
-  manager->Wrap(info.This());
-  return;
-}
-
-KeyboardLayoutManager::KeyboardLayoutManager(Nan::Callback *callback) : callback(callback) {
-}
+KeyboardLayoutManager::KeyboardLayoutManager(v8::Isolate *isolate, Nan::Callback *callback) : isolate_(isolate), callback(callback) {}
 
 KeyboardLayoutManager::~KeyboardLayoutManager() {
   delete callback;

--- a/src/keyboard-layout-manager.cc
+++ b/src/keyboard-layout-manager.cc
@@ -1,0 +1,36 @@
+#include "keyboard-layout-manager.h"
+
+using namespace v8;
+
+NAN_MODULE_INIT(init) {
+  Nan::HandleScope scope;
+  Local<FunctionTemplate> newTemplate = Nan::New<FunctionTemplate>(KeyboardLayoutManager::New);
+  newTemplate->SetClassName(Nan::New<String>("KeyboardLayoutManager").ToLocalChecked());
+  newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
+
+  Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
+
+  Nan::SetMethod(proto, "getCurrentKeyboardLayout", KeyboardLayoutManager::GetCurrentKeyboardLayout);
+  Nan::SetMethod(proto, "getCurrentKeyboardLanguage", KeyboardLayoutManager::GetCurrentKeyboardLanguage);
+  Nan::SetMethod(proto, "getInstalledKeyboardLanguages", KeyboardLayoutManager::GetInstalledKeyboardLanguages);
+  Nan::SetMethod(proto, "getCurrentKeymap", KeyboardLayoutManager::GetCurrentKeymap);
+
+  Nan::Set(target, Nan::New("KeyboardLayoutManager").ToLocalChecked(), Nan::GetFunction(newTemplate).ToLocalChecked());
+}
+
+#if NODE_MAJOR_VERSION >= 10
+NAN_MODULE_WORKER_ENABLED(keyboard_layout_manager, init)
+#else
+NODE_MODULE(keyboard_layout_manager, init)
+#endif
+
+NAN_METHOD(KeyboardLayoutManager::New) {
+  Nan::HandleScope scope;
+
+  Local<Function> callbackHandle = info[0].As<Function>();
+  Nan::Callback *callback = new Nan::Callback(callbackHandle);
+
+  KeyboardLayoutManager *manager = new KeyboardLayoutManager(info.GetIsolate(), callback);
+  manager->Wrap(info.This());
+  return;
+}

--- a/src/keyboard-layout-manager.h
+++ b/src/keyboard-layout-manager.h
@@ -9,17 +9,19 @@
 
 class KeyboardLayoutManager : public Nan::ObjectWrap {
  public:
-  static void Init(v8::Local<v8::Object> target, v8::Local<v8::Object> module);
   void HandleKeyboardLayoutChanged();
 
- private:
-  KeyboardLayoutManager(Nan::Callback *callback);
-  ~KeyboardLayoutManager();
   static NAN_METHOD(New);
   static NAN_METHOD(GetCurrentKeyboardLayout);
   static NAN_METHOD(GetCurrentKeyboardLanguage);
   static NAN_METHOD(GetInstalledKeyboardLanguages);
   static NAN_METHOD(GetCurrentKeymap);
+
+ private:
+  KeyboardLayoutManager(v8::Isolate* isolate, Nan::Callback *callback);
+  ~KeyboardLayoutManager();
+
+  v8::Isolate* isolate() { return isolate_; }
 
 #if defined(__linux__) || defined(__FreeBSD__)
   Display *xDisplay;
@@ -27,6 +29,7 @@ class KeyboardLayoutManager : public Nan::ObjectWrap {
   XIM xInputMethod;
 #endif
 
+  v8::Isolate *isolate_;
   Nan::Callback *callback;
 };
 


### PR DESCRIPTION
This modifies this module to be context aware --> https://nodejs.org/api/addons.html#addons_worker_support

It does this by using NAN_MODULE_WORKER_ENABLED where it is available and ensuring that we appropriately clean up the CFNotificationCenter subscription when appropriate with context deletion / GC.

This will allow folks to use this in node 12 worker threads and in future Electron process models.

This PR also includes a refactor to move `::Init` and `::New` into a common file as they were duplicated across files for no reason.

It's tacked on top of #50 so I suggest merging that one first.

This should also probably be released as a major to avoid any issues with it suddenly becoming ~self~ context-aware