### PR TITLE
Added C4309 to ignored warnings on Windows build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -31,6 +31,7 @@
             },
           },
           'msvs_disabled_warnings': [
+            4309,  # 'static_cast': truncation of constant value
             4018,  # signed/unsigned mismatch
             4244,  # conversion from 'type1' to 'type2', possible loss of data
             4267,  # conversion from 'size_t' to 'type', possible loss of data


### PR DESCRIPTION
### Identify the Bug

https://github.com/atom/keyboard-layout/issues/58

### Description of the Change

Added 4309 warning to ignored warnings list in binding.gyp

### Alternate Designs

Do not fail on warnings altogether by changing WarnAsError to false in binding.gyp

### Possible Drawbacks

Warning could be an issue under some conditions.

### Verification Process

Not applicable.

### Release Notes

Fixes issue with building for Windows 32bit using Electron 10.