### PR TITLE
Add openssl_fips variable to binding.gyp to support node 17

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  "variables": {
+    "openssl_fips" : "0" 
+  },
   "targets": [
     {
       "target_name": "keyboard-layout-manager",


### PR DESCRIPTION
### Identify the Bug

When working with Node 17 (locally), the builds were failing due to missing `openssl_fips` configuration.

### Description of the Change

Added a default variable for `openssl_fips` with value 0.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

I did not check the code with Node 16 and below.

### Verification Process

Nothing.

### Release Notes

- Fixed openssl_fips configuration to support Node 17.